### PR TITLE
"Fix" d'un bug d'onglets Firefox

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Testeur d'horaires
-// @version      2.0-beta.12
+// @version      2.0-beta.13
 // @description  https://github.com/ADecametre/testeur-dhoraires-polymtl
 // @author       ADécamètre
 // @match        https://dossieretudiant.polymtl.ca/WebEtudiant7/PresentationHorairePersServlet
@@ -45,7 +45,7 @@ function creerInterfaceTesteur(active = null){
                     style="background-color:#${active ? "f0" : "0f"}03"
                     onclick="${!active ?
                         `if(opener?.window){
-                            window.open('', \`${windowAEP}\`)
+                            window.open('${urlAEP}', \`${windowAEP}\`)
                         }else{
                             location.assign('${urlAEP}')
                         }`
@@ -57,7 +57,7 @@ function creerInterfaceTesteur(active = null){
             ${!disabled && !active ? "" :
                 `<a onclick="
                     if(opener?.window){
-                        window.open('', \`${windowAEP}\`)
+                        window.open('${urlAEP}', \`${windowAEP}\`)
                     }else{
                         ${disabled ? "window.open" : "location.assign"}('${urlAEP}')
                     }"


### PR DESCRIPTION
Fix #12
Le problème n'est pas réglé, mais au moins, la page qui s'ouvre n'est plus vide. ¯\_(ツ)_/¯ (C'est supposé focus sur l'onglet déjà ouvert du générateur d'horaires et non ouvrir un nouvel onglet.)